### PR TITLE
Fixed: stat writing, if last week stat is empty

### DIFF
--- a/src/npmstat.js
+++ b/src/npmstat.js
@@ -257,6 +257,17 @@ class WriteNpmStat {
             const stats = this.getLastWeekNpmStat();
             stats.then((stats) => {
                 const day = StatDate.formatStart(new Date());
+                if (Object.keys(stats).length === 0) {
+                    const statKey = day.concat("_", "-");
+                    const statValue = [];
+                    statValue.push(day);
+                    if (this.#writePackageName) {
+                        statValue.push(this.#packageName);
+                    }
+                    statValue.push("-");
+                    statValue.push(0);
+                    stats[statKey] = statValue;
+                }
                 const grouped = this.#groupStats(
                     lastWeek,
                     stats,


### PR DESCRIPTION
## Issue ticket link
fixed #60 

## Describe your changes
return row with 0 download

## Type of change (Please delete options that are not relevant)
- [x] Bug fix (non-breaking change which fixes an issue)

